### PR TITLE
fix get senderID to work with IPFS API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ipfs-pubsub-dc",
+  "name": "ipfs-pubsub-1on1",
   "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/get-peer-id.js
+++ b/src/get-peer-id.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const getPeerID = (ipfs) => {
-  return ipfs._peerInfo.id._idB58String || ipfs._peerInfo.id
+const getPeerID = async (ipfs) => {
+  return (await ipfs.id()).id
 }
 
 exports.getPeerID = getPeerID

--- a/test/direct-channel.test.js
+++ b/test/direct-channel.test.js
@@ -52,6 +52,7 @@ describe('DirectChannel', function() {
   describe('create a channel', function() {
     it('has two participants', async () => {
       const c = new Channel(ipfs1, ipfs2._peerInfo.id._idB58String)
+      await c._setup()
       assert.deepEqual(c.peers, expectedPeerIDs)
       c.close()
     })
@@ -59,13 +60,16 @@ describe('DirectChannel', function() {
     it('has correct ID', async () => {
       const expectedID = path.join('/', PROTOCOL, expectedPeerIDs.join('/'))
       const c = new Channel(ipfs1, id2)
+      await c._setup()
       assert.deepEqual(c.id, expectedID)
       c.close()
     })
 
     it('has two peers', async () => {
       const c1 = new Channel(ipfs1, id2)
+      await c1._setup()
       const c2 = new Channel(ipfs2, id1)
+      await c2._setup()
       assert.deepEqual(c1.peers, expectedPeerIDs)
       assert.deepEqual(c2.peers, expectedPeerIDs)
       assert.equal(c1.id, path.join('/', PROTOCOL, expectedPeerIDs.join('/')))


### PR DESCRIPTION
Fix #1 by changing how we get the senderID.

I had to change some setup code to happen when opening the channel instead of in the constructor due to getting the senderID being async