### PR TITLE
Always use Channel.open to create a channel

### DIFF
--- a/test/direct-channel.test.js
+++ b/test/direct-channel.test.js
@@ -52,25 +52,21 @@ describe('DirectChannel', function() {
 
   describe('create a channel', function() {
     it('has two participants', async () => {
-      const c = new Channel(ipfs1, id2)
-      await c._setup()
+      const c = await Channel.open(ipfs1, id2)
       assert.deepEqual(c.peers, expectedPeerIDs)
       c.close()
     })
 
     it('has correct ID', async () => {
       const expectedID = path.join('/', PROTOCOL, expectedPeerIDs.join('/'))
-      const c = new Channel(ipfs1, id2)
-      await c._setup()
+      const c = await Channel.open(ipfs1, id2)
       assert.deepEqual(c.id, expectedID)
       c.close()
     })
 
     it('has two peers', async () => {
-      const c1 = new Channel(ipfs1, id2)
-      await c1._setup()
-      const c2 = new Channel(ipfs2, id1)
-      await c2._setup()
+      const c1 = await Channel.open(ipfs1, id2)
+      const c2 = await Channel.open(ipfs2, id1)
       assert.deepEqual(c1.peers, expectedPeerIDs)
       assert.deepEqual(c2.peers, expectedPeerIDs)
       assert.equal(c1.id, path.join('/', PROTOCOL, expectedPeerIDs.join('/')))
@@ -226,7 +222,7 @@ describe('DirectChannel', function() {
     it('throws an error if pubsub is not supported by given IPFS instance', async () => {
       let c, err
       try {
-        c = new Channel({}, id2)
+        c = await Channel.open({}, id2)
       } catch (e) {
         err = e
       }


### PR DESCRIPTION
This PR will make sure we use Channel.open everywhere and don't directly create a Channel instance using the constructor.